### PR TITLE
Deduplicate sorted lists

### DIFF
--- a/ext/normalize_iplist.c
+++ b/ext/normalize_iplist.c
@@ -116,8 +116,7 @@ static VALUE serialize(VALUE self __attribute__((unused)), VALUE in) {
 
     size_t n = RARRAY_LEN(in), total = n, trim = 0;
     VALUE out = rb_str_new(NULL, n*5);
-    VALUE out_str = rb_string_value(&out);
-    char *out_p = RSTRING_PTR(out_str);
+    char *out_p = RSTRING_PTR(out);
     VALUE extras = rb_ary_new2(0);
 
 #define EMIT(p, ip, mask) do {                                          \
@@ -137,7 +136,7 @@ static VALUE serialize(VALUE self __attribute__((unused)), VALUE in) {
             ++trim;
             total += ip.last-ip.first; /* NB: one less because we've been counted once */
             VALUE tmp = rb_str_new(NULL, (1+ip.last-ip.first)*5);
-            char *p = RSTRING_PTR(rb_string_value(&tmp));
+            char *p = RSTRING_PTR(tmp);
             for (uint32_t v = ip.first; v <= ip.last; ++v)
                 EMIT(p, v, 32);
             rb_ary_push(extras, tmp);
@@ -154,8 +153,8 @@ static VALUE serialize(VALUE self __attribute__((unused)), VALUE in) {
         rb_str_set_len(out, (n-trim)*5);
         rb_str_concat(out, rb_ary_join(extras, rb_str_new(NULL, 0)));
     }
-    qsort(RSTRING_PTR(rb_string_value(&out)), total, 5, compare_serialized);
-    char *outp = RSTRING_PTR(rb_string_value(&out));
+    char *outp = RSTRING_PTR(out);
+    qsort(outp, total, 5, compare_serialized);
     char *trimmedp = dedup(outp, total);
     rb_str_set_len(out, trimmedp-outp);
     return out;

--- a/normalize-iplist.gemspec
+++ b/normalize-iplist.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "normalize-iplist"
-  s.version = "0.7"
+  s.version = "0.7.1"
   s.email = "julian.squires@adgear.com"
   s.summary = "IP list normalization/serialization"
   s.files = ["Rakefile", "README.rdoc", "ext/normalize_iplist.c", "ext/extconf.rb"]

--- a/test/test_normalize_text.rb
+++ b/test/test_normalize_text.rb
@@ -90,8 +90,28 @@ class NormalizeIPListNormalizeTextTest < Test::Unit::TestCase
     end
   end
 
-
   def test_normalize_permits_dumb_single_entry_ranges
     assert_equal(['4.0.0.0'], NormalizeIPList.normalize_text(['4.0.0.0,4.0.0.0']))
+  end
+
+  # Issue #3: Some sequences of duplicates are not coalesced properly
+  def test_normalize_issue_3
+    input = <<EOF.split("\n")
+65.96.66.64
+65.96.66.64
+65.96.66.66
+65.96.66.66
+65.96.66.67
+65.96.66.68
+65.96.66.69
+65.96.66.69
+65.96.66.72
+65.96.66.71
+65.96.66.71
+EOF
+    assert_equal(['65.96.66.64', '65.96.66.66', '65.96.66.67',
+                  '65.96.66.68', '65.96.66.69', '65.96.66.71',
+                  '65.96.66.72'],
+                 NormalizeIPList.normalize_text(input))
   end
 end


### PR DESCRIPTION
Astonishingly, this was missing.  I need to replace the test suite with one with property testing...

(Well, lists got deduped, but it interacted badly with coalescing, which assumed deduplication beforehand.)
