### PR TITLE
Support zero-padded addresses in validation

### DIFF
--- a/ext/normalize_iplist.c
+++ b/ext/normalize_iplist.c
@@ -284,9 +284,7 @@ static VALUE validate_generic_stream(VALUE in, VALUE out, long n) {
             current_octet = n_octets = 0;
         case SEEKING_DIGIT:
             ++n_octets;
-            if (c == '0') {
-                state = (n_octets == 4) ? SEEKING_MASKLESS_TERMINAL : SEEKING_DOT;
-            } else if (c >= '1' && c <= '9') {
+            if (c >= '0' && c <= '9') {
                 current_octet = c-'0';
                 state = (n_octets == 4) ? SEEKING_MASKLESS_TERMINAL : SEEKING_OCTET_DOT;
             } else

--- a/normalize-iplist.gemspec
+++ b/normalize-iplist.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "normalize-iplist"
-  s.version = "0.8"
+  s.version = "0.8.1"
   s.email = "julian.squires@adgear.com"
   s.summary = "IP list normalization/serialization"
   s.files = ["Rakefile", "README.rdoc", "ext/normalize_iplist.c", "ext/extconf.rb"]

--- a/test/test_validate.rb
+++ b/test/test_validate.rb
@@ -86,7 +86,7 @@ class NormalizeIPListValidateTest < Test::Unit::TestCase
                '192.168.0.',
                'f192.168.0.1'].join("\n"))
       f.rewind
-      assert_equal([2, 3, 5, 6],
+      assert_equal([2, 5, 6, 7],
                    NormalizeIPList.validate(f, 4))
     end
   end
@@ -111,8 +111,15 @@ class NormalizeIPListValidateTest < Test::Unit::TestCase
                '255.0255.255.0',
                'f192.168.0.1'].join("\n"))
       f.rewind
-      assert_equal([2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
+      assert_equal([2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17],
                    NormalizeIPList.validate(f, 20))
     end
   end
+
+  def test_validate_zero_padded_ips
+    s = StringIO.new(['192.168.000.001/32',
+                      '192.168.000.032'].join("\n"))
+    assert_equal([], NormalizeIPList.validate(s, 3))
+  end
+
 end


### PR DESCRIPTION
Although I think it is silly to accept 010.000.000.099, I have been convinced that this is somehow useful.  (In fact, earlier versions supported this format, so this was a regression, now that I think of it.)
