### PR TITLE
Fix validation of truncated files

### DIFF
--- a/ext/normalize_iplist.c
+++ b/ext/normalize_iplist.c
@@ -373,7 +373,11 @@ static VALUE validate_generic_stream(VALUE in, VALUE out, long n) {
             e = has_more ? p + RSTRING_LEN(buf) : NULL;
         }
 
-        if ('\n' == c && INVALID == state) {
+        if ('\n' == c &&
+            !(START == state ||
+              SEEKING_NEWLINE == state ||
+              SEEKING_MASKLESS_TERMINAL == state ||
+              SEEKING_MASK_TERMINAL == state)) {
             if (line_number > FIXNUM_MAX)
                 rb_raise(rb_eArgError, "input was too large (more than fixnum lines)");
             rb_ary_push(out, INT2FIX(line_number));

--- a/normalize-iplist.gemspec
+++ b/normalize-iplist.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "normalize-iplist"
-  s.version = "0.8.1"
+  s.version = "0.8.2"
   s.email = "julian.squires@adgear.com"
   s.summary = "IP list normalization/serialization"
   s.files = ["Rakefile", "README.rdoc", "ext/normalize_iplist.c", "ext/extconf.rb"]

--- a/test/test_validate.rb
+++ b/test/test_validate.rb
@@ -118,8 +118,14 @@ class NormalizeIPListValidateTest < Test::Unit::TestCase
 
   def test_validate_zero_padded_ips
     s = StringIO.new(['192.168.000.001/32',
-                      '192.168.000.032'].join("\n"))
-    assert_equal([], NormalizeIPList.validate(s, 3))
+                      '192.168.000.032',
+                      '00000'].join("\n"))
+    assert_equal([3], NormalizeIPList.validate(s, 3))
   end
 
+  def test_validate_catches_truncated_final
+    ['00000', '192.', '192.168.', '192.168.0', '129.168.0.'].each do |ip|
+      assert_equal([1], NormalizeIPList.validate(StringIO.new(ip)))
+    end
+  end
 end


### PR DESCRIPTION
This would previously accept incomplete IPs at the end of a file as valid.
